### PR TITLE
Rename Storage.open to .read

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Then to access your file:
 ```
 %Attachment{file_data: file} = attachment
 
-{:ok, contents} = Capsule.open(file)
+{:ok, contents} = Capsule.read(file)
 ```
 
 <sup>1</sup> *See [integrations](integrations) for streamlined use with Ecto.*
@@ -48,7 +48,7 @@ There are three main concepts in capsule: storage, upload, and the special one, 
 
 A "storage" is a [behaviour](https://elixirschool.com/en/lessons/advanced/behaviours/) that implements the following "file-like" callbacks:
 
-* open
+* read
 * put
 * copy
 * delete

--- a/lib/capsule.ex
+++ b/lib/capsule.ex
@@ -5,13 +5,13 @@ defmodule Capsule do
     %{encapsulation | metadata: encapsulation.metadata |> Map.merge(data)}
   end
 
-  def open(%Encapsulation{storage: module_name} = encapsulation) do
+  def read(%Encapsulation{storage: module_name} = encapsulation) do
     storage =
       module_name
       |> String.replace_prefix("", "Elixir.")
       |> String.replace_prefix("Elixir.Elixir", "Elixir")
       |> String.to_existing_atom()
 
-    storage.open(encapsulation)
+    storage.read(encapsulation)
   end
 end

--- a/lib/storage.ex
+++ b/lib/storage.ex
@@ -3,7 +3,7 @@ defmodule Capsule.Storage do
 
   @type option :: {atom(), any()}
 
-  @callback open(Encapsulation.t(), [option]) :: {:ok, binary()} | {:error, String.t()}
+  @callback read(Encapsulation.t(), [option]) :: {:ok, binary()} | {:error, String.t()}
   @callback put(Upload.t(), [option]) :: {:ok, Encapsulation.t()} | {:error, String.t()}
   @callback copy(Upload.t(), Path.t(), [option]) ::
               {:ok, Encapsulation.t()} | {:error, String.t()}

--- a/lib/upload.ex
+++ b/lib/upload.ex
@@ -7,7 +7,7 @@ defprotocol Capsule.Upload do
 end
 
 defimpl Capsule.Upload, for: Capsule.Encapsulation do
-  defdelegate contents(encapsulation), to: Capsule, as: :open
+  defdelegate contents(encapsulation), to: Capsule, as: :read
 
   def name(%{metadata: %{name: name}}), do: name
   def name(%{id: id}), do: id

--- a/test/capsule_test.exs
+++ b/test/capsule_test.exs
@@ -11,10 +11,10 @@ defmodule CapsuleTest do
     end
   end
 
-  describe "open/1" do
-    test "opens file in storage" do
+  describe "read/1" do
+    test "reads stored file contents into memory" do
       assert {:ok, _} =
-               Capsule.open(%Encapsulation{
+               Capsule.read(%Encapsulation{
                  id: "name",
                  storage: "Elixir.Capsule.Storages.Mock"
                })
@@ -22,7 +22,7 @@ defmodule CapsuleTest do
 
     test "handles storage without Elixir prefix" do
       assert {:ok, _} =
-               Capsule.open(%Encapsulation{
+               Capsule.read(%Encapsulation{
                  id: "name",
                  storage: "Capsule.Storages.Mock"
                })

--- a/test/support/mock_storage.ex
+++ b/test/support/mock_storage.ex
@@ -18,5 +18,5 @@ defmodule Capsule.Storages.Mock do
   def delete(%Encapsulation{}, _opts \\ []), do: {:ok, nil}
 
   @impl Storage
-  def open(%Encapsulation{}, _opts \\ []), do: {:ok, "mock file contents"}
+  def read(%Encapsulation{}, _opts \\ []), do: {:ok, "mock file contents"}
 end


### PR DESCRIPTION
This will hopefully reduce potential confusion/ambiguity with the File API.