### PR TITLE
 stream & copy files across storages

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ This helper was added in order to support DRYing up storage access. In most apps
 defmodule AvatarUploader do
   use Capsule.Uploader, storages: [cache: Disk, store: S3]
 
-  def storage_options(upload, :cache, opts) do
+  def build_options(upload, :cache, opts) do
     Keyword.put(opts, :prefix, "cache/#{Date.utc_today()}")
   end
 
-  def storage_options(upload, :store, opts) do
+  def build_options(upload, :store, opts) do
     opts
     |> Keyword.put(:prefix, "users/#{opts[:user_id]}/avatar")
-    |> Keyword.drop(:user_id)
+    |> Keyword.drop([:user_id])
   end
 
   def build_metadata(upload, :store, _), do: [uploaded_at: DateTime.utc_now()]

--- a/lib/capsule.ex
+++ b/lib/capsule.ex
@@ -2,6 +2,31 @@ defmodule Capsule do
   alias Capsule.Locator
   alias Capsule.Errors.InvalidStorage
 
+  def copy(locator, dest_storage, opts \\ []) 
+  def copy(%Locator{storage: source_storage}, dest_storage, _opts) when source_storage==dest_storage do
+    raise "Use `#{source_storage.clone/3}` when you want to clone a file on the same storage"
+  end
+  def copy(%Locator{id: id} = locator, dest_storage, opts) do
+    source_storage = storage!(locator)
+
+    id
+    |> source_storage.stream(opts)
+    |> dest_storage.put(Keyword.put(opts, :name, id))
+    |> case do
+          {:ok, id} ->
+            locator =
+              Capsule.add_metadata(
+                Locator.new!(id: id, storage: dest_storage),
+                %{copied_from: source_storage}
+              )
+
+            {:ok, locator}
+
+          error_tuple ->
+            error_tuple
+        end
+  end
+
   def add_metadata(%Locator{} = locator, key, val),
     do: add_metadata(locator, %{key => val})
 
@@ -21,4 +46,5 @@ defmodule Capsule do
   end
 
   def storage!(%Locator{storage: module_name}) when is_atom(module_name), do: module_name
+
 end

--- a/lib/capsule/storage.ex
+++ b/lib/capsule/storage.ex
@@ -4,10 +4,18 @@ defmodule Capsule.Storage do
   @type option :: {atom(), any()}
   @type locator_id :: String.t()
 
+  @callback url(locator_id, [option]) :: binary() | nil
+  @callback url(locator_id) :: binary() | nil
+
+  @callback path(locator_id, [option]) :: binary() | nil
+  @callback path(locator_id) :: binary() | nil
+
   @callback read(locator_id, [option]) :: {:ok, binary()} | {:error, String.t()}
   @callback read(locator_id) :: {:ok, binary()} | {:error, String.t()}
+
   @callback put(Upload.t(), [option]) :: {:ok, locator_id} | {:error, String.t()}
   @callback put(Upload.t()) :: {:ok, locator_id} | {:error, String.t()}
+  
   @callback delete(locator_id, [option]) :: :ok | {:error, String.t()}
   @callback delete(locator_id) :: :ok | {:error, String.t()}
 end

--- a/lib/capsule/storage.ex
+++ b/lib/capsule/storage.ex
@@ -13,9 +13,12 @@ defmodule Capsule.Storage do
   @callback read(locator_id, [option]) :: {:ok, binary()} | {:error, String.t()}
   @callback read(locator_id) :: {:ok, binary()} | {:error, String.t()}
 
+  @callback stream(locator_id, [option]) :: IO.Stream.t() | File.Stream.t() | Stream.t()
+  @callback stream(locator_id) :: IO.Stream.t() | File.Stream.t() | Stream.t()
+
   @callback put(Upload.t(), [option]) :: {:ok, locator_id} | {:error, String.t()}
   @callback put(Upload.t()) :: {:ok, locator_id} | {:error, String.t()}
-  
+
   @callback delete(locator_id, [option]) :: :ok | {:error, String.t()}
   @callback delete(locator_id) :: :ok | {:error, String.t()}
 end

--- a/lib/capsule/upload.ex
+++ b/lib/capsule/upload.ex
@@ -14,4 +14,6 @@ defimpl Capsule.Upload, for: Capsule.Locator do
 
   def name(%{metadata: %{name: name}}), do: name
   def name(%{id: id}), do: id
+
+  def path(%{} = locator), do: Capsule.storage!(locator).path(locator)
 end

--- a/lib/capsule/upload.ex
+++ b/lib/capsule/upload.ex
@@ -7,7 +7,7 @@ defprotocol Capsule.Upload do
 
   @spec path(struct()) :: String.t() | nil
   def path(upload)
-end
+end 
 
 defimpl Capsule.Upload, for: Capsule.Locator do
   def contents(locator), do: Capsule.storage!(locator).read(locator.id)

--- a/lib/capsule/upload.ex
+++ b/lib/capsule/upload.ex
@@ -4,6 +4,9 @@ defprotocol Capsule.Upload do
 
   @spec name(struct()) :: String.t()
   def name(upload)
+
+  @spec path(struct()) :: String.t() | nil
+  def path(upload)
 end
 
 defimpl Capsule.Upload, for: Capsule.Locator do


### PR DESCRIPTION

- added a `copy` function to copy files across storages (eg. S3 -> Disk)
- added `stream` callback for storages

still to do:
- optimise further by using `S3.download_file(bucket, id, "path/to/file")` specifically when copying from S3 to Disk
- check that all copy paths (other than S3->Disk) work as expected
- add tests for the above (probably in capsule_supplement?)